### PR TITLE
NVH updated to work with blocktree; improvements

### DIFF
--- a/elm/build.sbt
+++ b/elm/build.sbt
@@ -1,3 +1,6 @@
 name := "elm"
 
-libraryDependencies += "org.scalaj" % "scalaj-http_2.11" % "2.3.0" % "test"
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "cats" % "0.8.1",
+  "org.scalaj" % "scalaj-http_2.11" % "2.3.0" % "test"
+)

--- a/elm/src/main/scala/io/scalac/elm/api/BlockchainApiRoute.scala
+++ b/elm/src/main/scala/io/scalac/elm/api/BlockchainApiRoute.scala
@@ -38,7 +38,7 @@ class BlockchainApiRoute(val settings: Settings, nodeViewHolder: ActorRef)(impli
   def blocks: Route = get {
     path("blocks") {
       complete {
-        getBlockchain.map(_.mainChain.map(_.id.base58).asJson)
+        getBlockchain.map(_.mainChain.toList.map(_.id.base58).asJson)
       }
     }
   }

--- a/elm/src/main/scala/io/scalac/elm/history/ElmBlocktree.scala
+++ b/elm/src/main/scala/io/scalac/elm/history/ElmBlocktree.scala
@@ -1,14 +1,14 @@
 package io.scalac.elm.history
 
-import io.scalac.elm.history.ElmBlocktree.{FullState, Node}
-import io.scalac.elm.state.{ElmMemPool, ElmMinState, ElmWallet}
+import cats.data.Xor
+import io.scalac.elm.history.ElmBlocktree._
+import io.scalac.elm.state.ElmMinState
 import io.scalac.elm.transaction.{ElmBlock, ElmTransaction}
-import io.scalac.elm.util.ByteKey
+import io.scalac.elm.util.{ByteKey, Error}
 import scorex.core.NodeViewComponentCompanion
 import scorex.core.consensus.BlockChain
 import scorex.core.consensus.History.{BlockId, HistoryComparisonResult, RollbackTo}
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
-import scorex.core.utils.ScorexLogging
 
 import scala.annotation.tailrec
 import scala.util.Try
@@ -20,29 +20,18 @@ object ElmBlocktree {
     def removeChild(childId: ByteKey): Node = copy(children = children - childId)
   }
 
-  /**
-    * In order to main multiple blockchains we need a quick way determinig the state for each block in the tree.
-    * While MemPool is not directly related to the chain, it's convenient to store it here in case the Forger,
-    * does not use all avaialable transactions. When forging a new block, the Forger should merge the main MemPool with
-    * the one stored on the parent block.
-    *
-    * I don't think this is a great design. Fristly, becaus the blockchain is storing that state, secondly because it creates
-    * cyclic dependencies between packages. But at this time it seems the most convenient.
-    */
-  case class FullState(minState: ElmMinState, wallet: ElmWallet, memPool: ElmMemPool)
-
   val zero: ElmBlocktree = {
     val zeroNode = Node(ElmBlock.zero, Set.empty, 0, 0, 0)
-    val zeroState = FullState(ElmMinState(), ElmWallet(), new ElmMemPool)
-    ElmBlocktree(Map(zeroNode.id -> zeroNode), Set(zeroNode.id), Map(zeroNode.id -> zeroState))
+    ElmBlocktree(Map(zeroNode.id -> zeroNode), Set(zeroNode.id))
   }
+
+  case object BlockValidationError extends Error
 }
 
 case class ElmBlocktree private(
-  blocks: Map[ByteKey, Node] = Map(),
-  leaves: Set[ByteKey],
-  state: Map[ByteKey, FullState]
-) extends BlockChain[PublicKey25519Proposition, ElmTransaction, ElmBlock, ElmSyncInfo, ElmBlocktree] with ScorexLogging {
+  blocks: Map[ByteKey, Node],
+  leaves: Set[ByteKey]
+) extends BlockChain[PublicKey25519Proposition, ElmTransaction, ElmBlock, ElmSyncInfo, ElmBlocktree] {
 
   override type NVCT = ElmBlocktree
 
@@ -50,53 +39,47 @@ case class ElmBlocktree private(
   val N = 8
   val confirmationDepth = 5
 
-  def append(block: ElmBlock, unusedTxs: ElmMemPool): ElmBlocktree = {
+  def append(block: ElmBlock, minState: ElmMinState): Error Xor ElmBlocktree = {
     val blockId = block.id.key
     val parentId = block.parentId.key
 
-    if (leaves(parentId)) {
-      val score = calculateScore(block, state(parentId).minState)
+    if (isValid(block)) {
       val parent = blocks(parentId)
+      val score = calculateScore(block, parent.height, minState)
       val updatedParent = parent.addChild(blockId)
       val newNode = Node(block, Set.empty, parent.height + 1, score, parent.accumulatedScore + score)
 
-      val newMinState = state(parentId).minState.applyModifier(block).get // block should be validated before
-      val newWallet = state(parentId).wallet.scanPersistent(block)
-      val fullState = FullState(newMinState, newWallet, unusedTxs)
-
       val updatedBlocks = blocks + (parentId -> updatedParent) + (blockId -> newNode)
-      val updatedTree = ElmBlocktree(updatedBlocks, leaves + blockId, state + (blockId -> fullState))
+      val updatedTree = ElmBlocktree(updatedBlocks, leaves + blockId)
       val limitedTree = limitBranches(N, updatedTree)
-      limitedTree
+      Xor.right(limitedTree)
     } else {
-      log.error(s"Parent ID [${parentId.base58}] of new block [${blockId.base58}] was not found among the leaves")
-      this
+      Xor.left(BlockValidationError)
     }
   }
 
-  def calculateScore(block: ElmBlock, minState: ElmMinState): Long = {
+  def calculateScore(block: ElmBlock, parentHeight: Int, minState: ElmMinState): Long = {
     val coinstake = block.txs.head
     val partialScores = for {
       in <- coinstake.inputs
       txOut <- minState.get(in.closedBoxId)
-      depth <- txOut.depth
-    } yield txOut.value * depth
+      height <- txOut.height
+    } yield txOut.value * (parentHeight - height)
 
     partialScores.sum
   }
 
-  /**
-    * FullState of the main chain
-    */
-  def fullState: FullState =
-    state(maxLeaf.id)
-
-  def mainChain: List[Node] =
+  def mainChain: Stream[Node] =
     chainOf(maxLeaf.id)
 
-  def chainOf(blockId: ByteKey): List[Node] =
+  override lazy val height: Int = maxLeaf.height
+
+  /**
+    * Traverse the tree from leaf to root to return a single chain (branch)
+    */
+  def chainOf(blockId: ByteKey): Stream[Node] =
     blocks.get(blockId).filter(_ != ElmBlock.zero.id.key)
-      .map(node => node :: chainOf(node.id)).getOrElse(Nil)
+      .map(node => node #:: chainOf(node.id)).getOrElse(Stream.Empty)
 
   override def blockById(blockId: BlockId): Option[ElmBlock] =
     blocks.get(blockId).map(_.block)
@@ -125,13 +108,13 @@ case class ElmBlocktree private(
   /**
     * Find a leaf with the lowest score
     */
-  private def minLeaf: Node =
+  def minLeaf: Node =
     leaves.map(blocks).minBy(_.accumulatedScore)
 
   /**
     * Find a leaf with the highest score - the last block of the main chain
     */
-  private def maxLeaf: Node =
+  def maxLeaf: Node =
     leaves.map(blocks).maxBy(_.accumulatedScore)
 
   /**
@@ -159,7 +142,7 @@ case class ElmBlocktree private(
       val leaf = blocks(leafId)
       val parent = blocks(leaf.block.parentId.key)
       val updatedParent = parent.removeChild(leafId)
-      val updatedTree = ElmBlocktree(blocks - leafId, tree.leaves - leafId, state - leafId)
+      val updatedTree = ElmBlocktree(blocks - leafId, tree.leaves - leafId)
 
       if (updatedParent.children.nonEmpty)
         updatedTree
@@ -167,6 +150,14 @@ case class ElmBlocktree private(
         removeBranch(parent.id, updatedTree)
     }
   }
+
+  private def isValid(block: ElmBlock): Boolean = {
+    //TODO: implement fully
+    leaves(block.id.key)
+  }
+
+
+
 
   // Unused methods:
 
@@ -184,9 +175,6 @@ case class ElmBlocktree private(
 
   @deprecated("unused method (actually the place of usage is unused)")
   override def companion: NodeViewComponentCompanion = ???
-
-  @deprecated("unnecessary")
-  override def height(): Int = maxLeaf.height
 
   @deprecated("unnecessary")
   override def heightOf(blockId: BlockId): Option[Int] =

--- a/elm/src/main/scala/io/scalac/elm/state/ElmWallet.scala
+++ b/elm/src/main/scala/io/scalac/elm/state/ElmWallet.scala
@@ -20,55 +20,32 @@ object ElmWallet {
     val pair = Curve25519.createKeyPair(seed)
     PrivateKey25519(pair._1, pair._2)
   }
-
-  case class TimedTxOutput(out: TxOutput, timestamp: Long) {
-    def coinAge(currentTime: Long) = BigInt(currentTime - timestamp) * out.value
-  }
-
-  //TODO: config
-  val baseFee = 10L
 }
 
 /**
-  *
   * @param secret key pair
   * @param chainTxOutputs stores confirmed unspent outputs relevant to this Wallet
   * @param currentBalance sum of confirmed unspent outputs
   */
 case class ElmWallet(secret: PrivateKey25519 = generateSecret(),
-                     chainTxOutputs: Map[ByteKey, TimedTxOutput] = Map(),
+                     chainTxOutputs: Map[ByteKey, TxOutput] = Map.empty,
                      currentBalance: Long = 0)
   extends Wallet[PublicKey25519Proposition, ElmTransaction, ElmBlock, ElmWallet] {
 
   override type S = PrivateKey25519
   override type PI = PublicKey25519Proposition
-
   override type NVCT = ElmWallet
 
   private val pubKeyBytes: ByteKey = secret.publicKeyBytes
 
-  override def secretByPublicImage(publicImage: PI): Option[S] = {
-    if (publicImage.address == secret.publicImage.address) Some(secret) else None
-  }
 
-  /**
-    * Only one secret is supported so this method always returns unmodified wallet
-    */
-  override def generateNewSecret(): ElmWallet = this
-
-  override def secrets: Set[S] = Set(secret)
-
-  override def rollback(to: VersionTag): Try[ElmWallet] = ???
-
-  override def publicKeys: Set[PublicKey25519Proposition] = Set(secret.publicImage)
-
-  def generator: PublicKey25519Proposition = publicKeys.head // our wallet will always have exactly 1 key-pair
+  def generator: PublicKey25519Proposition = secret.publicImage
 
   override def scanOffchain(tx: ElmTransaction): ElmWallet = {
     val outs = for {
       txIn <- tx.inputs
       txOut <- chainTxOutputs.get(txIn.closedBoxId)
-    } yield txOut.out
+    } yield txOut
 
     val sum = outs.map(_.value).sum
     val outIds = outs.map(_.id.key)
@@ -79,11 +56,6 @@ case class ElmWallet(secret: PrivateKey25519 = generateSecret(),
     ElmWallet(secret, reducedChainTxOuts, currentBalance - sum)
   }
 
-  override def scanOffchain(txs: Seq[ElmTransaction]): ElmWallet =
-    txs.foldLeft(this)((w, tx) => w.scanOffchain(tx))
-
-  override def historyTransactions: Seq[WalletTransaction[PublicKey25519Proposition, ElmTransaction]] = ???
-
   override def scanPersistent(modifier: ElmBlock): ElmWallet = {
     val transactions = modifier.transactions.getOrElse(Nil)
 
@@ -92,10 +64,10 @@ case class ElmWallet(secret: PrivateKey25519 = generateSecret(),
       val outs = for {
         tx <- transactions
         out <- tx.outputs if out.proposition.pubKeyBytes.key == pubKeyBytes
-      } yield out.id.key -> TimedTxOutput(out, tx.timestamp)
+      } yield out.id.key -> out
 
       val increasedOutputs = chainTxOutputs ++ outs
-      val sum = outs.map(_._2.out.value).sum
+      val sum = outs.map(_._2.value).sum
       ElmWallet(secret, increasedOutputs, currentBalance + sum)
     }
 
@@ -103,29 +75,23 @@ case class ElmWallet(secret: PrivateKey25519 = generateSecret(),
     if (modifier.generator.pubKeyBytes.key == pubKeyBytes) {
       val coinstakeIns = transactions.headOption.toList.flatMap(_.inputs)
       val reducedOutputs = increasedWallet.chainTxOutputs -- coinstakeIns.map(_.closedBoxId.key)
-      val sum = coinstakeIns.map(in => increasedWallet.chainTxOutputs(in.closedBoxId.key).out.value).sum
+      val sum = coinstakeIns.map(in => increasedWallet.chainTxOutputs(in.closedBoxId.key).value).sum
       ElmWallet(secret, reducedOutputs, increasedWallet.currentBalance - sum)
     }
     else
       increasedWallet
   }
 
-  override def companion: NodeViewComponentCompanion = ???
-
-  override def boxes(): Seq[WalletBox[PublicKey25519Proposition, _ <: Box[PublicKey25519Proposition]]] = ???
-
-  def accumulatedCoinAge: BigInt =
-    chainTxOutputs.values.map(coinAge(System.currentTimeMillis)).sum
+  def accumulatedCoinAge(currentHeight: Int): Long =
+    chainTxOutputs.values.map(coinAge(currentHeight)).sum
 
   //FIXME: there is a possible race condition, the same wallet should not create more than 1 TX
-  def createPayment(to: PublicKey25519Proposition, amount: Long, priority: Int): Option[ElmTransaction] = {
+  //FIXME: solution: lock wallet in ElmNodeViewHolder
+  def createPayment(payee: PublicKey25519Proposition, amount: Long, fee: Long, currentHeight: Int): Option[ElmTransaction] = {
     //use newest outputs to save coin-age for mining
+    val sortedOuts = chainTxOutputs.values.toList.sortBy(coinAge(currentHeight)).reverse
 
-    val currentTime = System.currentTimeMillis()
-    val sortedOuts = chainTxOutputs.values.toList.sortBy(coinAge(currentTime)).reverse.map(_.out)
-    val fee = priority * baseFee
     val requiredAmount = amount + fee
-
     val requiredOuts = findSufficientOutputs[TxOutput, Long](sortedOuts, _.value, requiredAmount)
     val foundSum = requiredOuts.map(_.value).sum
 
@@ -137,27 +103,26 @@ case class ElmWallet(secret: PrivateKey25519 = generateSecret(),
         TxInput(out.id, signature)
       }
       val change = TxOutput(foundSum - requiredAmount, secret.publicImage)
-      val toRecipient = TxOutput(amount, to)
+      val toRecipient = TxOutput(amount, payee)
       val outputs = if (change.value > 0) List(toRecipient, change) else List(toRecipient)
-      Some(ElmTransaction(inputs, outputs, fee, currentTime))
+      Some(ElmTransaction(inputs, outputs, fee))
     }
   }
 
-  def createCoinstake(targetCoinAge: BigInt, totalFee: Long): ElmTransaction = {
-    val now = System.currentTimeMillis
-    val sortedOuts = chainTxOutputs.values.toList.sortBy(coinAge(now)).reverse
-    val selectedOuts = findSufficientOutputs[TimedTxOutput, BigInt](sortedOuts, coinAge(now), targetCoinAge)
+  def createCoinstake(targetCoinAge: Long, totalFee: Long, currentHeight: Int): ElmTransaction = {
+    val sortedOuts = chainTxOutputs.values.toList.sortBy(coinAge(currentHeight)).reverse
+    val selectedOuts = findSufficientOutputs(sortedOuts, coinAge(currentHeight), targetCoinAge)
 
-    val inputs = selectedOuts.map { to =>
-      val signature = Signature25519(Curve25519.sign(secret.privKeyBytes, to.out.bytes))
-      TxInput(to.out.id, signature)
+    val inputs = selectedOuts.map { out =>
+      val signature = Signature25519(Curve25519.sign(secret.privKeyBytes, out.bytes))
+      TxInput(out.id, signature)
     }
 
     val outputs =
-      TxOutput(selectedOuts.map(_.out.value).sum, secret.publicImage) ::
-      TxOutput(totalFee, secret.publicImage) :: Nil
+      TxOutput(selectedOuts.map(_.value).sum, secret.publicImage) ::
+        TxOutput(totalFee, secret.publicImage) :: Nil
 
-    ElmTransaction(inputs, outputs, 0, now)
+    ElmTransaction(inputs, outputs, 0)
   }
 
   private def findSufficientOutputs[T, N : Numeric](outs: List[T], extract: T => N, value: N): List[T] = {
@@ -170,6 +135,38 @@ case class ElmWallet(secret: PrivateKey25519 = generateSecret(),
     } else Nil
   }
 
-  private def coinAge(currentTime: Long)(out: TimedTxOutput): BigInt =
-    out.coinAge(currentTime)
+  private def coinAge(currentHeight: Int)(out: TxOutput): Long =
+    out.height.map(h => (currentHeight - h) * out.value).getOrElse(0L)
+
+
+
+
+  @deprecated("unnecessary")
+  override def secretByPublicImage(publicImage: PI): Option[S] = ???
+
+  @deprecated("unnecessary")
+  override def generateNewSecret(): ElmWallet = this
+
+  @deprecated("unnecessary")
+  override def secrets: Set[S] = Set(secret)
+
+  @deprecated("unnecessary")
+  override def rollback(to: VersionTag): Try[ElmWallet] = ???
+
+  @deprecated("unnecessary")
+  override def publicKeys: Set[PublicKey25519Proposition] = Set(secret.publicImage)
+
+  @deprecated("unnecessary")
+  override def companion: NodeViewComponentCompanion = ???
+
+  @deprecated("unnecessary")
+  override def boxes(): Seq[WalletBox[PublicKey25519Proposition, _ <: Box[PublicKey25519Proposition]]] = ???
+
+  @deprecated("unnecessary")
+  override def scanOffchain(txs: Seq[ElmTransaction]): ElmWallet =
+    txs.foldLeft(this)((w, tx) => w.scanOffchain(tx))
+
+  @deprecated("unnecessary")
+  override def historyTransactions: Seq[WalletTransaction[PublicKey25519Proposition, ElmTransaction]] = ???
+
 }

--- a/elm/src/main/scala/io/scalac/elm/transaction/ElmTransaction.scala
+++ b/elm/src/main/scala/io/scalac/elm/transaction/ElmTransaction.scala
@@ -13,7 +13,7 @@ object ElmTransaction extends NodeViewModifierCompanion[ElmTransaction] with Jso
   val codec = getCodec
 }
 
-case class ElmTransaction(inputs: Seq[TxInput], outputs: Seq[TxOutput], fee: Long, timestamp: Long)
+case class ElmTransaction(inputs: List[TxInput], outputs: List[TxOutput], fee: Long, timestamp: Long = System.currentTimeMillis())
   extends Transaction[PublicKey25519Proposition] {
 
   override type M = ElmTransaction

--- a/elm/src/main/scala/io/scalac/elm/transaction/TxOutput.scala
+++ b/elm/src/main/scala/io/scalac/elm/transaction/TxOutput.scala
@@ -16,7 +16,7 @@ case class TxOutput(
   value: Long,
   proposition: PublicKey25519Proposition,
   id: Array[Byte] = UUID.randomUUID().toString.getBytes(StandardCharsets.US_ASCII),
-  depth: Option[Int] = None
+  height: Option[Int] = None
 ) extends Box[PublicKey25519Proposition] {
 
   def bytes: Array[Byte] = TxOutput.bytes(this)

--- a/elm/src/main/scala/io/scalac/elm/util/Error.scala
+++ b/elm/src/main/scala/io/scalac/elm/util/Error.scala
@@ -1,0 +1,6 @@
+package io.scalac.elm.util
+
+/**
+  * Marker trait for errors
+  */
+trait Error


### PR DESCRIPTION
Implements #8 

Also several improvements added:

- `cats.data.Xor` instead of `scala.util.Try`
- cleaned bunch of code - marked unnecessary overriden methods as `@deprecated`
- updated coin-age calculation in `ElmWallet`
- `TxOutput` uses height instead of depth
- wallet payment api specifies fee directly (instead of priority)

